### PR TITLE
handle cancel or back press from survey - android

### DIFF
--- a/android/src/main/java/com/surveymonkey/RNSurveyMonkeyModule.java
+++ b/android/src/main/java/com/surveymonkey/RNSurveyMonkeyModule.java
@@ -166,8 +166,11 @@ public class RNSurveyMonkeyModule extends ReactContextBaseJavaModule {
     private final ActivityEventListener activityEventListener = new ActivityEventListener() {
         @Override
         public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
-            if (requestCode != REQUEST_CODE || resultCode == Activity.RESULT_CANCELED || data == null)
+            if (requestCode != REQUEST_CODE || resultCode == Activity.RESULT_CANCELED || data == null){
+                SMError e = (SMError) data.getSerializableExtra("smError");
+                surveyMonkeyError(e);
                 return;
+            }
 
             if (resultCode == Activity.RESULT_OK) {
                 String respondent = data.getStringExtra("smRespondent");


### PR DESCRIPTION
Once the user clicks on the back button or cancels the survey in android, there was no callback to handle in react native side, this code will give us the control to handle. It's well tested too.